### PR TITLE
chore(config): change default stages from commit to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_install_hook_types: [pre-commit, commit-msg, prepare-commit-msg]
-default_stages: [commit]
+default_stages: [pre-commit]
 
 repos:
   - repo: local

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_install_hook_types: [pre-commit, commit-msg, prepare-commit-msg]
-default_stages: [commit]
+default_stages: [pre-commit]
 minimum_pre_commit_version: 3.6.2
 
 repos:


### PR DESCRIPTION
"commit" as default stage is deprecated

https://github.com/pre-commit/pre-commit/blob/cc4a52241565440ce200666799eef70626457488/tests/clientlib_test.py#L348