### PR TITLE
Support Revert Commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         name: test-commit-checker-script
         entry: hooks/commit_message_checker/tests/test_commit_checker.py
         language: script
-        stages: [commit]
+        stages: [pre-commit]
         files: ^hooks/commit_message_checker/(commit_msg_checker\.py|tests/test_commit_checker\.py|tests/test_commits\.yml)$
 
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/hooks/apply-commit-message-template/apply-commit-message-template
+++ b/hooks/apply-commit-message-template/apply-commit-message-template
@@ -8,7 +8,8 @@
 #
 # When committing without the -m flag: "git commit", the commit message editor will be opened
 # with the contents of COMMIT_EDITMSG, which we set to our template
-if [ "$PRE_COMMIT_COMMIT_MSG_SOURCE" != "message" ] && [ "$PRE_COMMIT_COMMIT_MSG_SOURCE" != "commit" ]; then
+
+apply_message_template() {
 
     # Get the directory from the path - This is needed since this will be stored in a cache
     # directory so we need the path to that to access the template file with the correct path
@@ -21,4 +22,36 @@ if [ "$PRE_COMMIT_COMMIT_MSG_SOURCE" != "message" ] && [ "$PRE_COMMIT_COMMIT_MSG
 
     cat "$full_path" > .git/COMMIT_EDITMSG
 
-fi
+
+}
+
+# The PRE_COMMIT_COMMIT_MSG_SOURCE is the second argument passed to prepare-commit-msg hooks.
+# You can see the different options here: https://git-scm.com/docs/githooks#_prepare_commit_msg
+case "$PRE_COMMIT_COMMIT_MSG_SOURCE" in
+
+    "message")
+        # Do nothing, this is when you commit with -m
+    ;;
+    "template")
+        # Do nothing, this is when you commit with -t
+    ;;
+    "commit")
+        # Do nothing, this is called when you commit with -C, -c or --amend options
+    ;;
+    "merge")
+        # Do nothing, this is called when doing a merge, and some other situations like revert
+    ;;
+    "squash")
+        # Do nothing, this is called when doing a squash, e.g. during interactive rebase
+    ;;
+
+    "")
+        apply_message_template
+    ;;
+
+    *)
+        echo "$PRE_COMMIT_COMMIT_MSG_SOURCE source type not handled"
+        exit 1
+    ;;
+
+esac

--- a/hooks/commit_message_checker/commit_msg_checker.py
+++ b/hooks/commit_message_checker/commit_msg_checker.py
@@ -28,9 +28,12 @@ def commit_msg_is_valid(input_file, allow_prefix: bool) -> bool:
     # .+ - Matches one or more of any character (the subject)
     if not re.match(r"^(feat|fix|docs|style|refactor|test|chore|build)\([^)]+\): \S.*", commit_message):
 
+        if re.match(r"^(Revert )", commit_message):
+            return True
+
         if allow_prefix:
             if not re.match(r"^fixup! ", commit_message):
-                        return False
+                return False
         else:
             return False
 

--- a/hooks/commit_message_checker/tests/test_commits.yml
+++ b/hooks/commit_message_checker/tests/test_commits.yml
@@ -10,6 +10,7 @@ allowed_types:
 
 should_pass:
   - "<type>(scope): description"
+  - 'Revert "<type>(scope): description"'
 
 should_pass_with_fixup_allowed:
   - "fixup! <type>(scope): description"
@@ -18,6 +19,9 @@ should_fail:
   # Check that type cannot be part of a longer word
   - "<type>s(scope): description"
   - "<type>s: description"
+
+  # Missing type
+  - "(scope): description"
 
   # Problems with scope
   - "<type>: description"
@@ -41,3 +45,6 @@ should_fail:
   - "fix! <type>: description"
   - "fixups! <type>(scope): description"
   - "fixups! <type>: description"
+
+  # No space after Revert
+  - "Revert<type>(scope): description"


### PR DESCRIPTION
Allow Revert commits in the git commit checker.

This also ignore the application of our template git message when committing with git revert ... so the default Revert message is displayed instead