### PR TITLE
test(ci): run commit_checker tests in PR workflow

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -16,3 +16,11 @@ jobs:
           # Needed so we can check a range of commits
           fetch-depth: 0
       - uses: ./actions/check_commit_messages/
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          python ./hooks/commit_message_checker/tests/test_commit_checker.py
+        shell: bash


### PR DESCRIPTION
Adds running the tests we have so far in CI.
In the future this should be more sophisticated and use pytest maybe, but for now we only have one test so it is okay