### PR TITLE
feat(jira comment): add action which comments jira ticket to PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,26 @@ does not allow those prefixes, so will fail if a commit has this prefix. The rea
 is it allows users to create fixup commits with `git commit --fixup <commit SHA>`, but we don't
 want these merged to the main branch. To remind users to fixup these commits once a PR is ready for
 merging, this action does not allow them.
+
+# Comment JIRA ticket action
+
+This action allows you to automatically post a link to the JIRA ticket mentioned in the branch
+you are trying to merge in a PR.
+
+```yaml
+name: "Comment Jira Link to PR"
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  comment-jira-ticket:
+    runs-on: self-hosted
+    steps:
+      - uses: EmLogic/git-hooks/actions/comment_jira_ticket@main
+        with:
+          jira-project-tag: "HULK"
+          jira-url-path: "https://<your organisation>.atlassian.net/browse"
+```

--- a/actions/comment_jira_ticket/action.yml
+++ b/actions/comment_jira_ticket/action.yml
@@ -1,0 +1,58 @@
+name: "Comment JIRA ticket"
+
+description: |
+  This action searches for valid JIRA tickets on the current branch, and posts a link to that
+  JIRA issue to the PR.
+
+  For example, if your project name is HULK, you might have JIRA tickets such as HULK-103, HULK-104.
+  You might include these in the branch name you are trying to merge e.g. <your name>/HULK-103/add_config_file
+  This action will extract the JIRA ticket name and automatically post a link to that ticket to the PR.
+
+  If you have multiple tickets in your branch name, e.g. <your name>/HULK-103/HULK-104/new_feature, then both
+  tickets will be included in the message posted to the PR.
+
+inputs:
+  jira-project-tag:
+    description: |
+      Tag used in the JIRA project for identifying JIRA tickets. e.g. in the case of HULK-103, the
+      'HULK' part is the jira-project-tag
+    required: true
+  jira-url-path:
+    description: "The URL path to the JIRA tickets e.g. https://<your organisation>.atlassian.net/browse"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Get Jira Issue
+      id: get-jira-issue
+      run: |
+        match=$(echo "${{ github.head_ref }}" | grep -o '${{ inputs.jira-project-tag }}-[0-9]\+' || true)
+        if [[ -n "$match" ]]; then
+          # In order to output multiline strings, you do some weird stuff
+          # see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter
+          # see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings
+          {
+            echo 'JIRA_ISSUE<<EOF'
+            for item in $match; do
+              echo "Link to JIRA issue: ${{ inputs.jira-url-path }}/$item"
+            done
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+        else
+          echo "No ${{ inputs.jira-project-tag }} issue found in branch name."
+        fi
+      shell: bash
+
+    - name: Post Jira Issue
+      if: ${{ steps.get-jira-issue.outputs.JIRA_ISSUE != '' }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            // Back ticks are required for multiline bodies
+            body: `${{ steps.get-jira-issue.outputs.JIRA_ISSUE }}`
+          })


### PR DESCRIPTION
Add a github action that allows user to have a bot that posts to their PRs, with a JIRA ticket located in the branch name